### PR TITLE
Syh dev power control

### DIFF
--- a/User/application/module/chassis/chassis_power_control.c
+++ b/User/application/module/chassis/chassis_power_control.c
@@ -4,7 +4,7 @@
 #include "chassis_power_control.h"
 extern RC_ctrl_t rc_ctrl;
 extern FDCAN_HandleTypeDef hfdcan1;
-uint8_t cap_state = 0;
+uint8_t cap_state = 0;      // 超级电容状态标志，0表示默认模式，1表示暴走模式
 FDCAN_TxHeaderTypeDef cap_TX_header;
 float input_power = 50;
 

--- a/User/application/module/chassis/chassis_power_control.c
+++ b/User/application/module/chassis/chassis_power_control.c
@@ -7,6 +7,20 @@ extern FDCAN_HandleTypeDef hfdcan1;
 uint8_t cap_state = 0;
 FDCAN_TxHeaderTypeDef cap_TX_header;
 float input_power = 50;
+
+/**
+ * @brief 底盘功率控制函数
+ *
+ * 该函数用于动态调整机器人底盘的功率分配，确保底盘在不超过最大功率限制的情况下，
+ * 根据超级电容器的能量状态和用户输入（如加速键）来优化电机的输出功率。
+ * 函数通过计算每个电机的初始功率，并在总功率超过限制时进行功率缩放，
+ * 同时根据电容器的能量状态动态调整底盘的最大功率。
+ *
+ * @param chassis_power_control 指向底盘控制结构体的指针，包含电机PID控制数据和底盘状态信息。
+ *
+ * @note 该函数会根据电容器的能量状态和用户输入（如加速键）动态调整功率分配，
+ *       并在功率超过限制时对电机输出进行缩放，确保系统稳定运行。
+ */
 void chassis_power_control(chassis_control_t *chassis_power_control)
 {
     uint16_t max_power_limit = 40; //最大功率限制

--- a/User/components/device/supercap/supercap.c
+++ b/User/components/device/supercap/supercap.c
@@ -75,7 +75,7 @@ uint8_t CAP_CAN_DataSend(FDCAN_HandleTypeDef* hfdcan,float lim_power, uint8_t ca
     CAP_CAN_txbuf[0] = temp_data>>8;
     CAP_CAN_txbuf[1] = temp_data&0xff;
     CAP_CAN_txbuf[2] = CAP_CANData.set_mode;
-
+    // 将消息添加到CAN发送队列，并检查发送是否成功
     if (HAL_FDCAN_AddMessageToTxFifoQ(hfdcan, &Tx_Header, CAP_CAN_txbuf) != HAL_OK)
     {
         return 1;   //发送失败

--- a/User/components/device/supercap/supercap.c
+++ b/User/components/device/supercap/supercap.c
@@ -6,6 +6,15 @@ CapDataTypedef CAP_CANData;
 FDCAN_TxHeaderTypeDef  CAP_TxHeader;
 uint8_t CAP_CAN_txbuf[8];
 
+/**
+ * @brief 超级电容数据解析函数
+ *
+ * 该函数用于解析从CAN总线接收到的超级电容数据，将其转换为结构体中的浮点数值。
+ * 解析的数据包括输入功率、输出功率、电容电压、功率限制和当前状态。
+ *
+ * @param ptr       指向超级电容数据结构的指针，用于存储解析后的数据。
+ * @param rx_data   从CAN总线接收到的原始数据。
+ */
 void supercap_measure_parse(CapDataTypedef * ptr, const uint8_t *rx_data)
 {
     ptr->Pin = (float)((int16_t)(rx_data[0]<<8|rx_data[1]))/100.0f;
@@ -17,10 +26,13 @@ void supercap_measure_parse(CapDataTypedef * ptr, const uint8_t *rx_data)
 
 
 /**
- * @brief CAN接收超级电容数据回调，解析数据
- * @param pCAP_Data
- * @param rx_data
- * @return none
+ * @brief CAN接收超级电容数据回调函数
+ *
+ * 该函数是CAN接收数据的回调函数，用于处理从CAN总线接收到的超级电容数据。
+ * 当接收到的CAN ID匹配超级电容的发送ID时，调用数据解析函数 `supercap_measure_parse` 解析数据。
+ *
+ * @param rx_data   从CAN总线接收到的原始数据。
+ * @param can_id    接收到的CAN消息的ID。
  */
 //CAN接收数据回调，解析数据
 void CAP_CAN_RxCallback(uint8_t *rx_data, uint16_t can_id)
@@ -30,7 +42,17 @@ void CAP_CAN_RxCallback(uint8_t *rx_data, uint16_t can_id)
 
 }
 
-
+/**
+ * @brief 超级电容数据发送函数
+ *
+ * 该函数用于通过CAN总线向超级电容发送控制数据，包括功率限制和模式设置。
+ * 数据会被打包成CAN消息并发送到超级电容设备。
+ *
+ * @param hfdcan            FDCAN句柄，用于指定CAN总线。
+ * @param lim_power         设置的功率限制值。
+ * @param capower_enable    超级电容使能标志。
+ * @return uint8_t          返回发送状态：0表示成功，1表示失败。
+ */
 uint8_t CAP_CAN_DataSend(FDCAN_HandleTypeDef* hfdcan,float lim_power, uint8_t capower_enable)
 {
     FDCAN_TxHeaderTypeDef Tx_Header = {
@@ -63,7 +85,13 @@ uint8_t CAP_CAN_DataSend(FDCAN_HandleTypeDef* hfdcan,float lim_power, uint8_t ca
 
 
 
-//返回数据指针
+/**
+ * @brief 获取超级电容数据结构体指针
+ *
+ * 该函数返回指向超级电容数据结构的指针，用于访问超级电容的测量数据。
+ *
+ * @return CapDataTypedef*  返回超级电容数据结构的指针。
+ */
 CapDataTypedef *get_CAPower_measure_point(void)
 {
     return &CAP_CANData;


### PR DESCRIPTION
为底盘功率控制模块和超级电容模块添加详细注释

- 为 `chassis_power_control.c` 文件中的底盘功率控制逻辑添加详细注释，解释功率计算、缩放逻辑以及超级电容状态管理。
- 为 `supercap.c` 文件中的超级电容数据解析和CAN通信逻辑添加详细注释，解释数据解析过程、CAN消息发送和接收的实现细节。
- 添加注释以说明关键变量的作用、计算公式的来源以及代码的逻辑流程。
- 注释中还包括了注意事项和可能的优化点，以帮助后续开发者更好地理解代码。